### PR TITLE
Improve flow retry logic with dashboard reset

### DIFF
--- a/core/runtime/flow_engine.py
+++ b/core/runtime/flow_engine.py
@@ -1,5 +1,6 @@
 """Generic flow engine with retry and restart logic."""
 from __future__ import annotations
+import time
 from typing import Callable, Dict, List
 
 
@@ -47,6 +48,9 @@ class FlowEngine:
             attempts[idx] += 1
             retries = int(step.get("retry_count", 0))
             if attempts[idx] <= retries:
+                delay_ms = int(step.get("retry_delay_ms", 0))
+                if delay_ms > 0:
+                    time.sleep(delay_ms / 1000.0)
                 action = (step.get("retry_action") or "repeat").lower()
                 if action == "prev" and idx > 0:
                     attempts[idx] = 0  # reset current attempts

--- a/core/servers/l2mad/flows/buff.py
+++ b/core/servers/l2mad/flows/buff.py
@@ -10,7 +10,7 @@ FLOW = [
     {"op": "send_arduino", "cmd": "b"},  # Открыть дэшборд
     {"op": "sleep",     "ms": 900},
     {"op": "click_in", "zone": "dashboard_body", "tpl": "buffer_button", "timeout_ms": 12500, "thr": 0.87},
-    {"op": "wait", "zone": "dashboard_body", "tpl": "buffer_init", "timeout_ms": 2000, "thr": 0.87, "retry_count": 1, "retry_action": "prev"},
+    {"op": "wait", "zone": "dashboard_body", "tpl": "buffer_init", "timeout_ms": 2000, "thr": 0.87, "retry_count": 5, "retry_delay_ms": 1000, "retry_action": "prev"},
     {"op": "dashboard_is_locked", "zone": "dashboard_body", "tpl": "dashboard_is_locked", "timeout_ms": 12000, "thr": 0.80},
     {"op": "sleep",     "ms": 900},
     {"op": "click_in",  "zone": "dashboard_body", "tpl": "{mode_key}",    "timeout_ms": 2500, "thr": 0.88},

--- a/core/servers/l2mad/flows/tp.py
+++ b/core/servers/l2mad/flows/tp.py
@@ -12,7 +12,7 @@ FLOW = [
     {"op": "click_village",  "timeout_ms": 2000, "thr": 0.88},
     {"op": "sleep", "ms": 900},
     {"op": "click_location", "timeout_ms": 2000, "thr": 0.88},
-    {"op": "optional_click", "zone": "confirm", "tpl": "confirm", "timeout_ms": 1500, "thr": 0.90, "retry_count": 1, "retry_action": "prev"},
+    {"op": "optional_click", "zone": "confirm", "tpl": "confirm", "timeout_ms": 1500, "thr": 0.90, "retry_count": 5, "retry_delay_ms": 1000, "retry_action": "prev"},
     {"op": "sleep", "ms": 900},
     {"op": "dashboard_is_locked", "zone": "dashboard_body", "tpl": "dashboard_is_locked", "timeout_ms": 12000, "thr": 0.80},
 ]


### PR DESCRIPTION
## Summary
- add optional retry delay to flow engine and apply five retries with 1s delay
- reset dashboard and rerun flow on failure for buff and teleport workers

## Testing
- `python -m py_compile core/runtime/flow_engine.py core/servers/l2mad/flows/buff.py core/servers/l2mad/flows/tp.py core/features/buff_after_respawn.py core/features/tp_after_respawn.py`


------
https://chatgpt.com/codex/tasks/task_e_689e28ac7644832490c66cba9972f656