### PR TITLE
Refactor buff/tp respawn flows to shared engine

### DIFF
--- a/core/features/buff_after_respawn.py
+++ b/core/features/buff_after_respawn.py
@@ -5,7 +5,7 @@ import time
 from typing import Callable, Optional, Dict, Tuple
 
 from core.runtime.dashboard_guard import DASHBOARD_GUARD
-from core.runtime.flow_engine import FlowEngine
+from core.runtime.flow_engine import FlowEngine, FlowExecutor
 from core.vision.matching.template_matcher import match_in_zone
 
 BUFF_MODE_PROFILE = "profile"
@@ -35,6 +35,8 @@ class BuffAfterRespawnWorker:
         self._templates = {}
         self._flow = None
         self._mode = BUFF_MODE_PROFILE
+        self.window: Optional[Dict] = None
+        self._tag = "[buff]"
         self._load_cfg()
 
     def _log(self, msg: str) -> None:
@@ -57,40 +59,17 @@ class BuffAfterRespawnWorker:
         pass  # только dashboard
 
     def run_once(self) -> bool:
-        win = self._get_window() or {}
-        if not win:
+        self.window = self._get_window() or {}
+        if not self.window:
             self._on_status("[buff] window missing", False)
             return False
 
+        if not self._flow:
+            self._on_status("[buff] flow missing", False)
+            return False
+
         with DASHBOARD_GUARD.session():
-            if self._flow:
-                return self._run_flow(win)
-
-            # 1) открыть модуль бафа
-            if not self._click_any(win, ("dashboard_tab", "dashboard_body"), "buffer_button", 2000):
-                self._log("[buff] FAIL: buffer_button not found in dashboard_tab/body")
-                self._on_status("[buff] buffer button not found", False)
-                return False
-
-            # 2) дождаться инициализации модуля (если есть шаблон)
-            if "buffer_init" in self._templates:
-                ok_init = self._wait_template(win, "dashboard_body", "buffer_init", 2000)
-                self._log(f"[buff] buffer_init: {'OK' if ok_init else 'SKIP/FAIL'}")
-
-            # 3) клик по режиму
-            mode_key = self._mode_tpl_key()
-            if not self._click_in(win, "dashboard_body", mode_key, 2500):
-                self._log(f"[buff] FAIL: mode key not found → {mode_key}")
-                self._on_status(f"[buff] mode '{self._mode}' not found", False)
-                return False
-
-            # 4) восстановить HP (если есть)
-            if "buffer_restore_hp" in self._templates:
-                ok_rhp = self._click_in(win, "dashboard_body", "buffer_restore_hp", 1000)
-                self._log(f"[buff] restore_hp: {'CLICK' if ok_rhp else 'SKIP'}")
-
-            self._on_status("[buff] done", True)
-            return True
+            return self._run_flow()
 
     # ---------- internals ----------
     def _load_cfg(self):
@@ -125,7 +104,8 @@ class BuffAfterRespawnWorker:
             BUFF_MODE_FIGHTER: "buffer_mode_fighter",
         }[self._mode]
 
-    def _zone_ltrb(self, win: Dict, zone_decl):
+    def _zone_ltrb(self, zone_decl):
+        win = self.window or {}
         if isinstance(zone_decl, tuple) and len(zone_decl) == 4:
             return tuple(map(int, zone_decl))
         if isinstance(zone_decl, dict):
@@ -144,73 +124,73 @@ class BuffAfterRespawnWorker:
             return (l, t, l + w, t + h)
         return (0, 0, int(win.get("width", 0)), int(win.get("height", 0)))
 
-    def _is_visible(self, win: Dict, zone_key: str, tpl_key_or_parts, thr: float) -> bool:
+    def _is_visible(self, zone_key: str, tpl_key_or_parts, thr: float) -> bool:
         zone = self._zones.get(zone_key)
         if not zone:
             return False
-        ltrb = self._zone_ltrb(win, zone)
+        ltrb = self._zone_ltrb(zone)
         parts = tpl_key_or_parts
         if isinstance(parts, str):
             parts = self._templates.get(parts, [])
         if not parts:
             return False
-        return match_in_zone(win, ltrb, self.server, self._lang(), parts, thr) is not None
+        return match_in_zone(self.window, ltrb, self.server, self._lang(), parts, thr) is not None
 
-    def _wait_in(self, win: Dict, zone_key: str, tpl_key: str, timeout_ms: int, thr: float) -> bool:
+    def _wait_in(self, zone_key: str, tpl_key: str, timeout_ms: int, thr: float) -> bool:
         deadline = time.time() + timeout_ms / 1000.0
         while time.time() < deadline:
-            if self._is_visible(win, zone_key, tpl_key, thr):
+            if self._is_visible(zone_key, tpl_key, thr):
                 return True
             time.sleep(0.05)
         return False
 
-    def _wait_while_visible(self, win: Dict, zone_key: str, tpl_key: str, timeout_ms: int, thr: float) -> bool:
+    def _wait_while_visible(self, zone_key: str, tpl_key: str, timeout_ms: int, thr: float) -> bool:
         deadline = time.time() + timeout_ms / 1000.0
         while time.time() < deadline:
-            if not self._is_visible(win, zone_key, tpl_key, thr):
+            if not self._is_visible(zone_key, tpl_key, thr):
                 return True
             time.sleep(0.1)
         return False
 
-    def _wait_template(self, win: Dict, zone_key: str, tpl_key: str, timeout_ms: int, thr: float = None) -> bool:
+    def _wait_template(self, zone_key: str, tpl_key: str, timeout_ms: int, thr: float = None) -> bool:
         zone = self._zones.get(zone_key); tpl = self._templates.get(tpl_key)
         if not zone or not tpl:
             return False
-        ltrb = self._zone_ltrb(win, zone)
+        ltrb = self._zone_ltrb(zone)
         thr = self.click_threshold if thr is None else float(thr)
         deadline = time.time() + timeout_ms / 1000.0
         while time.time() < deadline:
-            if match_in_zone(win, ltrb, self.server, self._lang(), tpl, thr):
+            if match_in_zone(self.window, ltrb, self.server, self._lang(), tpl, thr):
                 return True
             time.sleep(0.05)
         return False
 
-    def _click_in(self, win: Dict, zone_key: str, tpl_key: str, timeout_ms: int, thr: float = None) -> bool:
+    def _click_in(self, zone_key: str, tpl_key: str, timeout_ms: int, thr: float = None) -> bool:
         zone = self._zones.get(zone_key); tpl = self._templates.get(tpl_key)
         if not zone or not tpl:
             return False
-        ltrb = self._zone_ltrb(win, zone)
+        ltrb = self._zone_ltrb(zone)
         thr = self.click_threshold if thr is None else float(thr)
         deadline = time.time() + timeout_ms / 1000.0
         while time.time() < deadline:
-            pt = match_in_zone(win, ltrb, self.server, self._lang(), tpl, thr)
+            pt = match_in_zone(self.window, ltrb, self.server, self._lang(), tpl, thr)
             if pt:
                 self.controller.send(f"click:{pt[0]},{pt[1]}")
                 return True
             time.sleep(0.05)
         return False
 
-    def _click_any(self, win: Dict, zone_keys, tpl_key: str, timeout_ms: int, thr: float = None) -> bool:
+    def _click_any(self, zone_keys, tpl_key: str, timeout_ms: int, thr: float = None) -> bool:
         thr = self.click_threshold if thr is None else float(thr)
         deadline = time.time() + timeout_ms / 1000.0
         while time.time() < deadline:
             for zk in zone_keys:
-                if self._click_in(win, zk, tpl_key, 1, thr):
+                if self._click_in(zk, tpl_key, 1, thr):
                     return True
             time.sleep(0.05)
         return False
 
-    def _dashboard_reset(self, win: Dict):
+    def _dashboard_reset(self):
         self._log("[buff] dashboard reset")
         thr = self.click_threshold
         while True:
@@ -218,106 +198,21 @@ class BuffAfterRespawnWorker:
             time.sleep(0.5)
             self.controller.send("b")  # dashboard_init
             time.sleep(0.5)
-            if not self._is_visible(win, "dashboard_body", "dashboard_init", thr):
+            if not self._is_visible("dashboard_body", "dashboard_init", thr):
                 continue
             self.controller.send("b")  # close again
             time.sleep(0.5)
-            if not self._is_visible(win, "dashboard_body", "dashboard_init", thr):
+            if not self._is_visible("dashboard_body", "dashboard_init", thr):
                 break
         self._log("[buff] dashboard reset done")
-
     # ---------- flow engine ----------
-    def _exec_flow_step(self, win: Dict, step: Dict, idx: int, total: int) -> bool:
-        op = step.get("op")
-        thr = float(step.get("thr", self.click_threshold))
-
-        self._log(f"[buff][step {idx}/{total}] {op}: {step}")
-
-        if op == "click_any":
-            ok = self._click_any(win, tuple(step["zones"]), step["tpl"], int(step["timeout_ms"]), thr)
-            self._log(f"[buff][step {idx}] result: {'OK' if ok else 'FAIL'}")
-            if not ok:
-                self._on_status(f"[buff] click_any fail: {step}", False)
-            return ok
-
-        elif op == "wait":
-            ok = self._wait_template(win, step["zone"], step["tpl"], int(step["timeout_ms"]), thr)
-            self._log(f"[buff][step {idx}] result: {'OK' if ok else 'FAIL'}")
-            if not ok:
-                self._on_status(f"[buff] wait fail: {step}", False)
-            return ok
-
-        elif op == "dashboard_is_locked":
-            # Если блок виден, кликаем слева раз в 1с, пока блок не исчезнет.
-            zone_key = step["zone"]
-            tpl_key = step["tpl"]              # ожидаем ключ шаблона блокировки
-            timeout_ms = int(step.get("timeout_ms", 12000))
-            interval_s = float(step.get("probe_interval_s", 1.0))
-
-            start_ts = time.time()
-            next_probe = 0.0
-            unlocked = False
-
-            while (time.time() - start_ts) * 1000.0 < timeout_ms:
-                locked_now = self._is_visible(win, zone_key, tpl_key, thr)
-                if not locked_now:
-                    unlocked = True
-                    break
-
-                now = time.time()
-                if now >= next_probe:
-                    self._log(f"[buff][step {idx}] locked → probe left-click")
-                    self._probe_left_click()
-                    next_probe = now + interval_s
-
-                time.sleep(0.08)
-
-            self._log(f"[buff][step {idx}] unlocked: {'YES' if unlocked else 'NO'}")
-            if not unlocked:
-                self._on_status("[buff] dashboard still locked", False)
-            return unlocked
-
-        elif op == "click_in":
-            tpl_key = step["tpl"]
-            if tpl_key == "{mode_key}":
-                tpl_key = self._mode_tpl_key()
-            ok = self._click_in(win, step["zone"], tpl_key, int(step["timeout_ms"]), thr)
-            self._log(f"[buff][step {idx}] result: {'OK' if ok else 'FAIL'}")
-            if not ok:
-                self._on_status(f"[buff] click_in fail: {step}", False)
-            return ok
-
-        elif op == "optional_click":
-            ok = self._click_in(win, step["zone"], step["tpl"], int(step.get("timeout_ms", 800)), thr)
-            self._log(f"[buff][step {idx}] result: {'CLICKED' if ok else 'SKIP'}")
-            return True
-
-        elif op == "sleep":
-            ms = int(step.get("ms", 50))
-            self._log(f"[buff][step {idx}] sleeping {ms} ms")
-            time.sleep(ms / 1000.0)
-            return True
-
-        elif op == "send_arduino":
-            cmd = step.get("cmd", "")
-            delay_ms = int(step.get("delay_ms", 100))
-            self._log(f"[buff][step {idx}] send_arduino '{cmd}', delay {delay_ms} ms")
-            self.controller.send(cmd)
-            time.sleep(delay_ms / 1000.0)
-            return True
-
-        else:
-            self._log(f"[buff][step {idx}] unknown op: {op}")
-            self._on_status(f"[buff] unknown op: {op}", False)
-            return False
-
-    def _run_flow(self, win: Dict) -> bool:
+    def _run_flow(self) -> bool:
         while True:
-            engine = FlowEngine(self._flow, lambda s, i, t: self._exec_flow_step(win, s, i, t))
+            engine = FlowEngine(self._flow, FlowExecutor(self))
             ok = engine.run()
             if ok:
                 self._log("[buff] flow DONE")
                 self._on_status("[buff] done", True)
                 return True
             self._log("[buff] flow failed → dashboard reset")
-            self._dashboard_reset(win)
+            self._dashboard_reset()

--- a/core/features/tp_after_respawn.py
+++ b/core/features/tp_after_respawn.py
@@ -8,7 +8,7 @@ import time
 from typing import Callable, Optional, Dict, Tuple
 
 from core.runtime.dashboard_guard import DASHBOARD_GUARD
-from core.runtime.flow_engine import FlowEngine
+from core.runtime.flow_engine import FlowEngine, FlowExecutor
 from core.vision.matching.template_matcher import match_in_zone
 from core.servers.l2mad.templates import resolver as l2mad_resolver
 
@@ -35,6 +35,7 @@ class TPAfterDeathWorker:
         self._zones: Dict[str, object] = {}
         self._templates: Dict[str, list] = {}
         self._flow = None
+        self._tag = "[tp]"
         self._load_cfg()
 
         self._method = TP_METHOD_DASHBOARD
@@ -233,122 +234,6 @@ class TPAfterDeathWorker:
                 break
         self._log("[tp] dashboard reset done")
 
-    # ---------- FLOW engine ----------
-    def _exec_flow_step(self, step: Dict, idx: int, total: int) -> bool:
-        op = step.get("op")
-        thr = float(step.get("thr", 0.87))
-        self._log(f"[tp][step {idx}/{total}] {op}: {step}")
-
-        if op == "click_any":
-            ok = self._click_any(tuple(step["zones"]), step["tpl"], int(step["timeout_ms"]), thr)
-            self._log(f"[tp][step {idx}] result: {'OK' if ok else 'FAIL'}")
-            if not ok:
-                self._on_status(f"[tp] click_any fail: {step}", False)
-            return ok
-
-        elif op == "wait":
-            ok = self._wait_template(step["zone"], step["tpl"], int(step["timeout_ms"]), thr)
-            self._log(f"[tp][step {idx}] result: {'OK' if ok else 'FAIL'}")
-            if not ok:
-                self._on_status(f"[tp] wait fail: {step}", False)
-            return ok
-
-        elif op == "dashboard_is_locked":
-            zone_key = step["zone"]
-            tpl_key = step["tpl"]
-            timeout_ms = int(step.get("timeout_ms", 12000))
-            interval_s = float(step.get("probe_interval_s", 1.0))
-
-            if isinstance(tpl_key, str) and not self._templates.get(tpl_key) and self._templates.get("dashboard_blocked"):
-                self._templates["dashboard_is_locked"] = self._templates["dashboard_blocked"]
-
-            start_ts = time.time()
-            next_probe = 0.0
-            unlocked = False
-
-            while (time.time() - start_ts) * 1000.0 < timeout_ms:
-                if self._is_dead():
-                    break
-
-                locked_now = self._is_visible(zone_key, tpl_key, thr)
-                if not locked_now:
-                    unlocked = True
-                    break
-
-                now = time.time()
-                if now >= next_probe:
-                    self._log(f"[tp][step {idx}] locked → probe left-click")
-                    self._probe_left_click()
-                    next_probe = now + interval_s
-
-                time.sleep(0.08)
-
-            self._log(f"[tp][step {idx}] unlocked: {'YES' if unlocked else 'NO'}")
-            if not unlocked:
-                self._on_status("[tp] dashboard still locked", False)
-            return unlocked
-
-        elif op == "click_in":
-            ok = self._click_in(step["zone"], step["tpl"], int(step["timeout_ms"]), thr)
-            self._log(f"[tp][step {idx}] result: {'OK' if ok else 'FAIL'}")
-            if not ok:
-                self._on_status(f"[tp] click_in fail: {step}", False)
-            return ok
-
-        elif op == "optional_click":
-            ok = self._click_in(step["zone"], step["tpl"], int(step.get("timeout_ms", 800)), thr)
-            self._log(f"[tp][step {idx}] result: {'CLICKED' if ok else 'SKIP'}")
-            return True
-
-        elif op == "click_village":
-            lang = self._lang()
-            village_png = f"{self._category_id}.png"
-            ok_res = l2mad_resolver.teleport_location(lang, self._category_id, village_png)
-            self._log(f"[tp][step {idx}] resolve village '{self._category_id}' → {'OK' if ok_res else 'FAIL'}")
-            if not ok_res:
-                self._on_status(f"[tp] village template missing: {self._category_id}", False)
-                return False
-            parts = ["dashboard", "teleport", "villages", self._category_id, village_png]
-            ok = self._click_in("dashboard_body", parts, int(step.get("timeout_ms", 2500)), float(step.get("thr", 0.88)))
-            self._log(f"[tp][step {idx}] click village → {'OK' if ok else 'FAIL'}")
-            if not ok:
-                self._on_status(f"[tp] village not found: {self._category_id}", False)
-            return ok
-
-        elif op == "click_location":
-            lang = self._lang()
-            loc_png = f"{self._location_id}.png"
-            ok_res = l2mad_resolver.teleport_location(lang, self._category_id, loc_png)
-            self._log(f"[tp][step {idx}] resolve location '{self._category_id}/{self._location_id}' → {'OK' if ok_res else 'FAIL'}")
-            if not ok_res:
-                self._on_status(f"[tp] location template missing: {self._category_id}/{self._location_id}", False)
-                return False
-            parts = ["dashboard", "teleport", "villages", self._category_id, loc_png]
-            ok = self._click_in("dashboard_body", parts, int(step.get("timeout_ms", 2500)), float(step.get("thr", 0.88)))
-            self._log(f"[tp][step {idx}] click location → {'OK' if ok else 'FAIL'}")
-            if not ok:
-                self._on_status(f"[tp] location not found: {self._location_id}", False)
-            return ok
-
-        elif op == "sleep":
-            ms = int(step.get("ms", 50))
-            self._log(f"[tp][step {idx}] sleeping {ms} ms")
-            time.sleep(ms / 1000.0)
-            return True
-
-        elif op == "send_arduino":
-            cmd = step.get("cmd", "")
-            delay_ms = int(step.get("delay_ms", 100))
-            self._log(f"[tp][step {idx}] send_arduino '{cmd}', delay {delay_ms} ms")
-            self.controller.send(cmd)
-            time.sleep(delay_ms / 1000.0)
-            return True
-
-        else:
-            self._log(f"[tp][step {idx}] unknown op: {op}")
-            self._on_status(f"[tp] unknown op: {op}", False)
-            return False
-
     def _run_flow(self) -> bool:
         if not self._flow:
             self._on_status("[tp] flow missing", False)
@@ -357,7 +242,7 @@ class TPAfterDeathWorker:
             self._on_status("[tp] missing window/category/location", False)
             return False
         while True:
-            engine = FlowEngine(self._flow, self._exec_flow_step)
+            engine = FlowEngine(self._flow, FlowExecutor(self))
             ok = engine.run()
             if ok:
                 self._log("[tp] flow DONE")
@@ -369,3 +254,34 @@ class TPAfterDeathWorker:
     def _tp_via_gatekeeper(self) -> bool:
         self._on_status("[tp] gatekeeper method not implemented yet", False)
         return False
+
+    # ---------- flow helpers ----------
+    def _click_village(self, step: Dict) -> bool:
+        lang = self._lang()
+        village_png = f"{self._category_id}.png"
+        ok_res = l2mad_resolver.teleport_location(lang, self._category_id, village_png)
+        self._log(f"[tp] resolve village '{self._category_id}' → {'OK' if ok_res else 'FAIL'}")
+        if not ok_res:
+            self._on_status(f"[tp] village template missing: {self._category_id}", False)
+            return False
+        parts = ["dashboard", "teleport", "villages", self._category_id, village_png]
+        thr = float(step.get("thr", 0.88))
+        ok = self._click_in("dashboard_body", parts, int(step.get("timeout_ms", 2500)), thr)
+        if not ok:
+            self._on_status(f"[tp] village not found: {self._category_id}", False)
+        return ok
+
+    def _click_location(self, step: Dict) -> bool:
+        lang = self._lang()
+        loc_png = f"{self._location_id}.png"
+        ok_res = l2mad_resolver.teleport_location(lang, self._category_id, loc_png)
+        self._log(f"[tp] resolve location '{self._category_id}/{self._location_id}' → {'OK' if ok_res else 'FAIL'}")
+        if not ok_res:
+            self._on_status(f"[tp] location template missing: {self._category_id}/{self._location_id}", False)
+            return False
+        parts = ["dashboard", "teleport", "villages", self._category_id, loc_png]
+        thr = float(step.get("thr", 0.88))
+        ok = self._click_in("dashboard_body", parts, int(step.get("timeout_ms", 2500)), thr)
+        if not ok:
+            self._on_status(f"[tp] location not found: {self._location_id}", False)
+        return ok

--- a/core/runtime/flow_engine.py
+++ b/core/runtime/flow_engine.py
@@ -1,7 +1,7 @@
 """Generic flow engine with retry and restart logic."""
 from __future__ import annotations
 import time
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Any
 
 
 class FlowEngine:
@@ -66,3 +66,107 @@ class FlowEngine:
             return False
 
         return True
+
+
+class FlowExecutor:
+    """Default step executor used by Buff/TP workers."""
+
+    def __init__(self, ctx: Any):
+        self.ctx = ctx
+
+    def __call__(self, step: Dict, idx: int, total: int) -> bool:
+        tag = getattr(self.ctx, "_tag", "[flow]")
+        op = step.get("op")
+        thr = float(step.get("thr", getattr(self.ctx, "click_threshold", 0.87)))
+        self.ctx._log(f"{tag}[step {idx}/{total}] {op}: {step}")
+
+        if op == "click_any":
+            ok = self.ctx._click_any(tuple(step["zones"]), step["tpl"], int(step["timeout_ms"]), thr)
+            self.ctx._log(f"{tag}[step {idx}] result: {'OK' if ok else 'FAIL'}")
+            if not ok:
+                self.ctx._on_status(f"{tag} click_any fail: {step}", False)
+            return ok
+
+        elif op == "wait":
+            ok = self.ctx._wait_template(step["zone"], step["tpl"], int(step["timeout_ms"]), thr)
+            self.ctx._log(f"{tag}[step {idx}] result: {'OK' if ok else 'FAIL'}")
+            if not ok:
+                self.ctx._on_status(f"{tag} wait fail: {step}", False)
+            return ok
+
+        elif op == "dashboard_is_locked":
+            zone_key = step["zone"]
+            tpl_key = step["tpl"]
+            timeout_ms = int(step.get("timeout_ms", 12000))
+            interval_s = float(step.get("probe_interval_s", 1.0))
+
+            start_ts = time.time()
+            next_probe = 0.0
+            unlocked = False
+
+            while (time.time() - start_ts) * 1000.0 < timeout_ms:
+                if getattr(self.ctx, "_is_dead", lambda: False)():
+                    break
+
+                locked_now = self.ctx._is_visible(zone_key, tpl_key, thr)
+                if not locked_now:
+                    unlocked = True
+                    break
+
+                now = time.time()
+                if now >= next_probe:
+                    self.ctx._log(f"{tag}[step {idx}] locked → probe left-click")
+                    self.ctx._probe_left_click()
+                    next_probe = now + interval_s
+
+                time.sleep(0.08)
+
+            self.ctx._log(f"{tag}[step {idx}] unlocked: {'YES' if unlocked else 'NO'}")
+            if not unlocked:
+                self.ctx._on_status(f"{tag} dashboard still locked", False)
+            return unlocked
+
+        elif op == "click_in":
+            tpl_key = step["tpl"]
+            if tpl_key == "{mode_key}" and hasattr(self.ctx, "_mode_tpl_key"):
+                tpl_key = self.ctx._mode_tpl_key()
+            ok = self.ctx._click_in(step["zone"], tpl_key, int(step["timeout_ms"]), thr)
+            self.ctx._log(f"{tag}[step {idx}] result: {'OK' if ok else 'FAIL'}")
+            if not ok:
+                self.ctx._on_status(f"{tag} click_in fail: {step}", False)
+            return ok
+
+        elif op == "optional_click":
+            ok = self.ctx._click_in(step["zone"], step["tpl"], int(step.get("timeout_ms", 800)), thr)
+            self.ctx._log(f"{tag}[step {idx}] result: {'CLICKED' if ok else 'SKIP'}")
+            return True
+
+        elif op == "click_village" and hasattr(self.ctx, "_click_village"):
+            ok = self.ctx._click_village(step)
+            self.ctx._log(f"{tag}[step {idx}] click village → {'OK' if ok else 'FAIL'}")
+            return ok
+
+        elif op == "click_location" and hasattr(self.ctx, "_click_location"):
+            ok = self.ctx._click_location(step)
+            self.ctx._log(f"{tag}[step {idx}] click location → {'OK' if ok else 'FAIL'}")
+            return ok
+
+        elif op == "sleep":
+            ms = int(step.get("ms", 50))
+            self.ctx._log(f"{tag}[step {idx}] sleeping {ms} ms")
+            time.sleep(ms / 1000.0)
+            return True
+
+        elif op == "send_arduino":
+            cmd = step.get("cmd", "")
+            delay_ms = int(step.get("delay_ms", 100))
+            self.ctx._log(f"{tag}[step {idx}] send_arduino '{cmd}', delay {delay_ms} ms")
+            self.ctx.controller.send(cmd)
+            time.sleep(delay_ms / 1000.0)
+            return True
+
+        else:
+            self.ctx._log(f"{tag}[step {idx}] unknown op: {op}")
+            self.ctx._on_status(f"{tag} unknown op: {op}", False)
+            return False
+


### PR DESCRIPTION
## Summary
- Route buff-after-respawn through shared FlowExecutor
- Rework TP worker to use FlowExecutor and helper methods
- Expand flow_engine with FlowExecutor implementing common steps

## Testing
- `python3 -m py_compile core/features/buff_after_respawn.py core/features/tp_after_respawn.py core/runtime/flow_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_689e45ca5e58832482bc73b7e681ab3e